### PR TITLE
Optimize posts page redirect logic

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,30 +1,29 @@
-"use client";
-
 import { Post } from "@/app/[locale]/types/post";
 import MainBlogCard from "@/app/[locale]/components/MainBlogCard";
 import BlogCard from "@/app/[locale]/components/BlogCard";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { getTranslations } from "next-intl/server";
+import { hasLocale } from "next-intl";
+import { routing } from "../../i18n/routing";
+import { notFound } from "next/navigation";
 
-export default function PostsPage() {
-  const [posts, setPosts] = useState<Post[]>([]);
-  const t = useTranslations("Home-Page");
-
-  // Fetch posts on mount
-  useEffect(() => {
-    async function fetchPosts() {
-      try {
-        const res = await fetch("https://jsonplaceholder.typicode.com/posts");
-        if (!res.ok) throw new Error("Failed to fetch posts");
-        const data: Post[] = await res.json();
-        setPosts(data);
-      } catch (error) {
-        console.error(error);
-      }
-    }
-    fetchPosts();
-  }, []);
+export default async function PostsPage({
+  params,
+}: {
+  params: { locale: string };
+}) {
+  const locale = params.locale;
+  if (!hasLocale(routing.locales, locale)) {
+    notFound();
+  }
+  const t = await getTranslations("Home-Page");
+  const res = await fetch("https://jsonplaceholder.typicode.com/posts", {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    notFound();
+  }
+  const posts: Post[] = await res.json();
 
   // Categories translated using t()
   const categories = [


### PR DESCRIPTION
Convert PostsPage to a server component to eliminate not-found content flash by redirecting before render.

The previous client-side fetching and rendering could lead to a brief display of content before a `notFound` redirect was triggered. By converting to a server component, locale validation and data fetching errors can trigger `notFound()` directly, preventing any UI from rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbb92be8-7f30-4a18-9062-0e08c258e432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbb92be8-7f30-4a18-9062-0e08c258e432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

